### PR TITLE
update: improving code examples for go, c# and python language

### DIFF
--- a/content/en/opentelemetry/guide/otlp_delta_temporality.md
+++ b/content/en/opentelemetry/guide/otlp_delta_temporality.md
@@ -243,9 +243,7 @@ public class Program
                     };
 				exporterOptions.Protocol = OtlpExportProtocol.HttpProtobuf;
 				metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
-			})
-            .SetMaxMetricStreams(3)
-            .SetMaxMetricPointsPerMetricStream(3);;
+			});
 		using var provider = providerBuilder.Build();
 
 		Counter<int> counter = meter.CreateCounter<int>("example.counter", "1", "Example counter");

--- a/content/en/opentelemetry/guide/otlp_delta_temporality.md
+++ b/content/en/opentelemetry/guide/otlp_delta_temporality.md
@@ -28,7 +28,9 @@ If you opt to send OTLP monotonic sums, histograms, or exponential histograms wi
 
 If you produce OTLP metrics from an OpenTelemetry SDK, you can configure your OTLP exporter to produce these metric types with delta aggregation temporality. In some languages you can use the recommended configuration by setting the `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` environment variable to `Delta` (case-insensitive). For a list of languages with support for this environment variable, read [the specification compliance matrix][4].
 
-If your SDK does not support this environment variable you can configure delta temporality in code. The following example configures an OTLP HTTP exporter and adds `1` to a counter every two seconds for a total of five minutes:
+If your SDK does not support this environment variable you can configure delta temporality in code. The following example configures an OTLP HTTP exporter and adds `1` to a counter every two seconds for a total of five minutes.
+
+**Note**: These examples are to get you started. You shouldn't apply patterns like using console or stdout exporters in production scenarios.
 
 {{< programming-lang-wrapper langs="python,go,java,.net" >}}
 
@@ -37,7 +39,8 @@ If your SDK does not support this environment variable you can configure delta t
 import time
 
 from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
-    OTLPMetricExporter, )
+    OTLPMetricExporter,
+)
 from opentelemetry.sdk.metrics import (
     Counter,
     Histogram,

--- a/content/en/opentelemetry/guide/otlp_delta_temporality.md
+++ b/content/en/opentelemetry/guide/otlp_delta_temporality.md
@@ -225,7 +225,6 @@ public class Program
     public static void Main()
     {
 		using var meter = new Meter("my-meter");
-        var endpoint = "http://metrics-http-default.telemetry.vtex.systems/v1/metrics";
 		var providerBuilder = Sdk.CreateMeterProviderBuilder().AddMeter(meter.Name);
 		providerBuilder
         .AddConsoleExporter((exporterOptions, metricReaderOptions) =>
@@ -242,8 +241,7 @@ public class Program
                     {
                         ExportIntervalMilliseconds = Convert.ToInt32("5000"),
                     };
-				exporterOptions.Protocol = OtlpExportProtocol.Grpc;
-                exporterOptions.Endpoint = new Uri(endpoint);
+				exporterOptions.Protocol = OtlpExportProtocol.HttpProtobuf;
 				metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Delta;
 			})
             .SetMaxMetricStreams(3)


### PR DESCRIPTION
<!-- *Note: Please remember to review the Datadog Documentation [Contribution Guidelines](https://github.com/DataDog/documentation/blob/master/CONTRIBUTING.md) if you have not yet done so.* -->

### What does this PR do? What is the motivation?
Improve the code base of delta temporality section. 

- For most language, there's no consoleExporter, what difficult the initial test. I did add the consoleExporter o Metric Provider for Go and Python, it will help the initial tests for users.
- The consoleExporter on C# language is not configured with the delta temporality, and it can cause confusion on tests when the stdout show cumulative temporality aggregation but the metrics as really are being sent with delta temporality. I did configure also the consoleExporter with delta temporality preference to don't cause any confusion.
- Also, I did configure all exporter with 5s of interval to make the code more interactive. In some languages, it can take 1 min to show the stdout results.

### Merge instructions

- [x] Please merge after reviewing

### Additional notes
I used this documentation for my delta tests and didn't understand why I was setting delta temporality and stdout was still showing cumulative temporality. After a few hours of troubleshooting, I realized it was just the consoleExporter configuration, so I hope this can help other uses not run into the scenario in the future.